### PR TITLE
update AKS kubernetes version

### DIFF
--- a/aks/main.tf
+++ b/aks/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = azurerm_resource_group.default.location
   resource_group_name = azurerm_resource_group.default.name
   dns_prefix          = "${random_pet.prefix.id}-k8s"
-  kubernetes_version  = "1.26.3"
+  kubernetes_version  = "1.27.9"
 
   default_node_pool {
     name            = "default"


### PR DESCRIPTION
Kubernetes Version 1.26.3 is not supported in West US 2:

> managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.26.3 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list